### PR TITLE
remove input; avoid exit code 1

### DIFF
--- a/stun/cli.py
+++ b/stun/cli.py
@@ -57,7 +57,6 @@ def main():
         print('NAT Type:', nat_type)
         print('External IP:', external_ip)
         print('External Port:', external_port)
-        input('Press any key to continue')
     except KeyboardInterrupt:
         sys.exit()
 


### PR DESCRIPTION
when i exec `pystun -i 10.198.74.192 -H stun.l.google.com -P 19302` use golang language, it also occur `Press any key to continue`,  and exit code is not zero; 
so i must change command as below:
`echo 0 | pystun -i 10.198.74.192 -H stun.l.google.com -P 19302`
