### PR TITLE
Fix issue with port change code.

### DIFF
--- a/stun/__init__.py
+++ b/stun/__init__.py
@@ -229,7 +229,7 @@ def get_nat_type(s, source_ip, source_port, stun_host=None, stun_port=3478):
                     changePortRequest = ''.join([ChangeRequest, '0004',
                                                  "00000002"])
                     log.debug("Do Test3")
-                    ret = stun_test(s, changedIP, port, source_ip, source_port,
+                    ret = stun_test(s, changedIP, changedPort, source_ip, source_port,
                                     changePortRequest)
                     log.debug("Result: %s", ret)
                     if ret['Resp']:


### PR DESCRIPTION
Hello, I believe that there is a bug in the NAT characterization code when it comes to telling the STUN host to 'change ports' in a reply. In the code the endpoint indicated for the port change request is:

**changedIP + port**, where port is the initial port of the first STUN server contacted. The problem is: the default port used to connect to that first STUN server **IS the same port used for 'changed port' returned from the changedIP host**. Consequently, when you send the 'change port request' you end up using the same port that the reply will be returned on. Meaning that as you send out the request you create the mapping in the NAT and end up falsely characterizing the NAT type as a 'restrictNAT' / end-point independent NAT, when actually the source port of the recipient still matters.

In a previous test you've already sent traffic to changedIP + changedPort which opens up that mapping. So you need to make it so the reply is returned on another port that hasn't been used yet. That is only possible if you reuse changedIP + changedPort and check for a response on the second IPs changedPort (which happens to be the first hosts port used, or the value for 'port') Let me know if you think this behaviour is correct. I've made heavy changes to this module myself and I'm still finding stuff I've missed.